### PR TITLE
Add css

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,11 @@
+tr.paragraphs-item-type-sci-purpose-methods.odd .form-item,
+tr.paragraphs-item-type-sci-purpose-methods.even .form-item {
+  white-space: normal;
+}
+.field-type-paragraphs .form-actions {
+  background-color: transparent;
+}
+.field-type-paragraphs .tabledrag-toggle-weight-wrapper,
+.field-type-paragraphs .field-multiple-drag {
+  display: none;
+}

--- a/dkan_sci_metadata.module
+++ b/dkan_sci_metadata.module
@@ -243,3 +243,12 @@ function dkan_sci_metadata_smm() {
   $output = MigrateSciMetadata::migrate();
   print ($output);
 }
+
+function dkan_sci_metadata_form_alter(&$form, &$form_state, $form_id) {
+  switch ($form_id) {
+    case 'dataset_node_form':
+      $path = drupal_get_path('module', 'dkan_sci_metadata');
+      drupal_add_css ($path . "/css/style.css");
+      break;
+  }
+}


### PR DESCRIPTION
connects #9 

To make the draggable bits optional we could modify https://www.drupal.org/project/no_table_drag to work with paragraphs.

### QA Steps
- Create a new dataset, click 'Add science purpose / methods'
- Confirm the paragraph form is the same width as the rest of the form

<img width="697" alt="paragraph-form" src="https://user-images.githubusercontent.com/314172/42612820-26608a9e-8563-11e8-890f-f6f44fa2f599.png">
